### PR TITLE
Implement support for fikonspråket #18. 

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -20,6 +20,9 @@
         <input type="radio" id="rovarspraket" value="rovarspraket" v-model="picked">
         <label for="rovarspraket">Rövarspråket</label>
         <br>
+        <input type="radio" id="fikonspraket" value="fikonspraket" v-model="picked">
+        <label for="fikonspraket">Fikonspråket</label>
+        <br>
       </div>
       <hr />
       <p>This is a demonstration project of a CI-pipeline. <br /> made as part of the WASP software engineering course</p>
@@ -49,6 +52,8 @@ const comp = {
         newmsg = pigspeak.piggify(this.piginput)
       } else if (this.picked === 'rovarspraket') {
         newmsg = pigspeak.rovarify(this.piginput)
+      } else if (this.picked === 'fikonspraket') {
+        newmsg = pigspeak.fikonify(this.piginput)
       }
       this.pigoutput = newmsg
     }

--- a/src/lib/pigspeak.js
+++ b/src/lib/pigspeak.js
@@ -22,6 +22,10 @@ function flatten (list) {
   }, [])
 }
 
+function split_at(list, index) {
+  return [list.slice(index), list.slice(0, index)]
+}
+
 /** pig latin */
 function pig_word(word) {
   let strArr = []
@@ -58,6 +62,15 @@ function rovar_word(word) {
   return format_word(wordArr.join(''), capitalize)
 }
 
+/** fikonspraket */
+function fikon_word(word) {
+  const firstChar = word.charAt(0)
+  const capitalize = (firstChar === firstChar.toUpperCase())
+  let index = Math.floor(word.length / 2)
+  let wordArr = split_at(word, index)
+  return format_word('fi' + wordArr.join('') + 'kon', capitalize)
+}
+
 const self = {
   /**
    * Translates english into piglatin.
@@ -80,6 +93,14 @@ const self = {
 
   rovarify(text) {
     return map_word(text.split(/\b/), rovar_word).join('')
+  },
+  /** Translates english into Fikonspråket
+   *
+   * Each word is split in two halves.
+   * The parts are then put in reverse order to form a new word started with "fi" and ended with "kon".
+   */
+  fikonify(text) {
+    return map_word(text.split(/\b/), fikon_word).join('')
   }
 }
 

--- a/test/unit/specs/pigspeak.spec.js
+++ b/test/unit/specs/pigspeak.spec.js
@@ -28,3 +28,15 @@ describe('pigspeak: rövarspråket', () => {
       .to.equal('Fofarorfofaror vovaror enon sosjojörorävovarorsosjojälol.')
   })
 })
+
+describe('pigspeak: fikonspråket', () => {
+  it('should convert words', () => {
+    expect(pigspeak.fikonify('datorgrafik')).to.equal('figrafikdatorkon')
+    expect(pigspeak.fikonify('korv')).to.equal('firvkokon')
+  })
+
+  it('should convert sentences', () => {
+    expect(pigspeak.fikonify('Inga speciella svenska tecken.'))
+      .to.equal('Fofarorfofaror vovaror enon sosjojörorävovarorsosjojälol.')
+  })
+})


### PR DESCRIPTION
Problem with Swedish characters ÅåÖöÄä. Treats each one of them as they don't belong in the word - And whenever they occur seems like they splitting the word to sub-words (where fikonspråket rules work fine). 
Maybe because \w is [a-zA-Z0-9_]?